### PR TITLE
fix sample list subscription err reference

### DIFF
--- a/resources/subscriptions/list.js
+++ b/resources/subscriptions/list.js
@@ -52,7 +52,7 @@ async function listSubscriptions() {
     */
       console.log(subscriptionDetails);
     }
-  } catch (error) {
+  } catch (err) {
     console.error(JSON.stringify(err));
   }
 }


### PR DESCRIPTION
## Purpose
* As seen on the documentation below, the catch condition is defining the variable `error` while the function to stringify is referencing `err`: 
https://docs.microsoft.com/en-gb/azure/developer/javascript/core/nodejs-sdk-azure-authenticate?tabs=azure-sdk-for-javascript#3-list-azure-subscriptions-with-service-principal

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code and run as stated by the documentation, an error should no longer appear:
Previously:
```js
ReferenceError: err is not defined
    at listSubscriptions (/Users/azure/dev/main.js:58:34)
    at Object.<anonymous> (/Users/azure/dev/main.js:62:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```

## What to Check
Verify that the following are valid
* Verify that the documentation also reflects these changes.