### PR TITLE
Method changed to beginStart

### DIFF
--- a/resources/virtual-machines/start-vm.js
+++ b/resources/virtual-machines/start-vm.js
@@ -32,7 +32,7 @@ async function startVM() {
     credentials,
     subscriptionId
   );
-  const result = await computeClient.virtualMachines.start(
+  const result = await computeClient.virtualMachines.beginStart(
     resourceGroupName,
     vmResourceName
   );


### PR DESCRIPTION
as the start method is deprecated and not available on the sdk

## Purpose
as start method is deprecated and changed to beginStart in the latest SDK

## Does this introduce a breaking change?
No

## Pull Request Type
What kind of change does this Pull Request introduce?
Bugfix
